### PR TITLE
BluerainConsumer

### DIFF
--- a/src/Provider.stories.tsx
+++ b/src/Provider.stories.tsx
@@ -1,4 +1,4 @@
-import { BlueRainConsumer, BlueRain } from './index';
+import { BlueRain,BlueRainConsumer } from './index';
 import React from 'react';
 import storiesOf from '../storybook/storiesOf';
 

--- a/src/Provider.stories.tsx
+++ b/src/Provider.stories.tsx
@@ -1,0 +1,11 @@
+import { BlueRainConsumer, BlueRain } from './index';
+import React from 'react';
+import storiesOf from '../storybook/storiesOf';
+
+storiesOf('Provider', module)
+
+	.add('BlueRainConsumer', () => (
+		<BlueRainConsumer>
+		{(BR: BlueRain) => <BR.Components.Text>Hello! I'm consuming BlueRain via Render Prop</BR.Components.Text>}
+		</BlueRainConsumer>
+	));

--- a/src/Provider.ts
+++ b/src/Provider.ts
@@ -17,4 +17,14 @@ const BlueRainProvider = withContext(
 const withBlueRain = (Component: React.ComponentType<any>) =>
 	getContext({ bluerain: PropTypes.object })(Component) as React.ComponentType<any>;
 
-export { BlueRainProvider, withBlueRain };
+//////// Consumer with children as a func (render prop) pattern
+const RenderComp = ({
+	children,
+	bluerain
+}: {
+	children: (...args: any[]) => React.ReactElement<any>;
+	bluerain: BlueRain;
+}) => children(bluerain);
+const BlueRainConsumer = withBlueRain(RenderComp);
+
+export { BlueRainProvider, withBlueRain, BlueRainConsumer };

--- a/src/components/SystemApp/SystemApp.ts
+++ b/src/components/SystemApp/SystemApp.ts
@@ -20,7 +20,6 @@ const SystemApp = ({ bluerain: BR, ...others }: { bluerain: BlueRain }) => {
 			}
 		]
 	};
-	console.log('BR', BR);
 
 	routes = BR.Filters.run('bluerain.system.app.schema', routes);
 	return BR.API.JsonToReact.parse(routes);

--- a/test/unit/AppRegistry.test.ts
+++ b/test/unit/AppRegistry.test.ts
@@ -1,0 +1,11 @@
+import AppRegistry from '../../src/registries/AppRegistry';
+
+// just only to test my code.These are not final tests
+describe('AppRegistry Unit Tests', () => {
+	it('will not throw error', () => {
+		expect(() => {
+			const appRegistry = new AppRegistry();
+			appRegistry.set('APP', () => 'APP');
+		}).toThrowError();
+	});
+});

--- a/test/unit/Components.test.tsx
+++ b/test/unit/Components.test.tsx
@@ -221,6 +221,14 @@ it('should return SystemApp Component', () => {
 it('should return SystemAp Component', () => {
 
 	const RouterSwitch=() => 'RouterSwitch';
+	const ReactRouterConfig={
+		androidBackButton: true,
+		deepLinking: true,
+		forceMemoryHistory:false,
+		historyConfigs: {},
+	};
+	BR.Configs.set('plugins.router',ReactRouterConfig);
+
 	BR.boot({ platform:[Platform],renderApp:false });
 
 	BR.Components.replace('RouterSwitch',RouterSwitch);


### PR DESCRIPTION
Added a BlueRainConsumer component, to match API with the upcoming context API in react V16.3. This uses a render prop pattern to provide BlueRain context. In upcoming releases, the internal mechanism will be shifted to the new API without any breaking changes.

### Usage

```javascript
<BlueRainConsumer>
{BR => <BR.Components.Text>Im consuming BlueRain via Render Prop</BR.Components.Text>}
</BlueRainConsumer>
```