### PR TITLE
App Icons 📱

### DIFF
--- a/bluerain.js
+++ b/bluerain.js
@@ -6,6 +6,12 @@ module.exports = {
 	],
 	apps: [
 		// All bluerain apps will also be added in this array
+		require('./test/apps/Alarm'),
+		require('./test/apps/Android'),
+		require('./test/apps/Apps'),
+		require('./test/apps/LightBulb'),
+		require('./test/apps/NoIcon'),
+		require('./test/apps/Sites'),
 	],
 	plugins: [
 		// All bluerain plugins will be added here

--- a/src/models/App.ts
+++ b/src/models/App.ts
@@ -2,37 +2,80 @@ import { BlueRain } from '../index';
 import { hookFn } from '../registries/HooksRegistry';
 import React from 'react';
 
-/**
- * A BlueRain App options interface
- * @property {String}	appName	Name of the app
- * @property {String}	slug	App's slug, used in to build URL
- * @property {String}	category	Category the App belongs to
- * @property {String}	description	App description
- * @property {String}	version	App version
- * @property {String}	appRoutePrefix	Path that will be prepended before slug to build URL.
- * @property {String}	path	Path of the app's home page
- * @property {ReactNode} icon	App's icon component
- * @property {boolean} hidden	If the app should be hidden in launcher listings
- * @property {object} hooks	Hooks object to subscrible all hooks (filters & events)
- * @property {object} components	Components object to register components in the system.
- * 									Internally it uses the `setOrReplace` method of the registry.
- * @property {Function} initialize	Initialize function called during the app initialization phase.
- */
+/** Possible values of AppIcon type field. */
+export type AppIconType = 'component' | 'name' | 'image';
+
+/** Base model of AppIcon */
+export interface AppIconBase {
+	type: AppIconType;
+}
+
+/** AppIcon as a custom component */
+export interface AppIconComponent extends AppIconBase {
+	type: 'component';
+
+	/**
+	 * Either a component or a component name (string).
+	 * In case of string, it will be fetched from Component Registry.
+	 */
+	component: React.ComponentType<any> | string;
+}
+
+/** AppIcon as a BR.Components.Icon component */
+export interface AppIconName extends AppIconBase {
+	type: 'name';
+
+	/** The name prop of the BR.Components.Icon component */
+	name: string;
+}
+
+/** AppIcon as an image */
+export interface AppIconImage extends AppIconBase {
+	type: 'image';
+
+	/** The image source */
+	source: string;
+}
+
+/** A BlueRain App options interface */
 export interface AppOptions {
+	/** Name of the app */
 	appName: string;
+
+	/** App's slug, used in to build URL */
 	slug?: string;
+
+	/** Category the App belongs to */
 	category?: string;
+
+	/** App description */
 	description?: string;
+
+	/** App version */
 	version?: string;
+
+	/** Path that will be prepended before slug to build URL */
 	appRoutePrefix?: string;
+
+	/** Path of the app's home page */
 	path?: string;
 
-	icon?: React.ComponentType<any>;
+	/** App's icon definition */
+	icon?: AppIconComponent | AppIconImage | AppIconName;
+
+	/** If the app should be hidden in launcher listings */
 	hidden?: boolean;
 
+	/** Hooks object to subscrible all hooks (filters & events) */
 	hooks?: { [id: string]: hookFn };
+
+	/**
+	 * Components object to register components in the system.
+	 * Internally it uses the `setOrReplace` method of the registry.
+	 */
 	components?: { [id: string]: React.ComponentType<any> };
 
+	/** Initialize function called during the app initialization phase. */
 	initialize?(config: {}, ctx: BlueRain): void;
 
 	[key: string]: any;

--- a/src/registries/AppRegistry.tsx
+++ b/src/registries/AppRegistry.tsx
@@ -12,7 +12,7 @@ const defaultAppRoutePrefix = '/app';
  * @property {Map<string, App>} data  Map(immutablejs) of all apps
  */
 class AppRegistry extends MapRegistry<App> {
-	BR: BlueRain;
+	private BR: BlueRain;
 
 	constructor(ctx: BlueRain) {
 		super('AppRegistry');
@@ -139,6 +139,61 @@ class AppRegistry extends MapRegistry<App> {
 		});
 
 		return appRoutes;
+	}
+
+	/**
+	 * Returns a React Element of an app's icon
+	 * @param {string} slug The slug of the app with which it is registered
+	 * @param {object} props The props that are passed to the element
+	 *
+	 * @returns {React.ReactElement<any> | null}
+	 */
+	getIconElement(
+		slug: string,
+		props: { size?: number, [key: string]: any } = {}
+	) : React.ReactElement<any> | null {
+
+		props = { size: 100, ...props };
+		const app: App = this.get(slug);
+
+		if (!app) {
+			throw new Error(`There's no app registered with "${name}" key in the registry.`);
+		}
+
+		const icon = app.icon;
+
+		if (!icon) {
+			return null;
+		}
+
+		let component: React.ComponentType<any>;
+
+		if (icon.type === 'component') {
+			component = (typeof icon.component === 'string')
+				? this.BR.Components.get(icon.component)
+				: component = icon.component;
+
+		} else if (icon.type === 'name') {
+			component = this.BR.Components.get('Icon');
+			props.name = icon.name;
+
+		} else if (icon.type === 'image') {
+			component = this.BR.Components.get('Image');
+			props.source = icon.source;
+
+			if (!props.style) {
+				props.style = {};
+			}
+
+			if (props.size) {
+				props.style.width = props.size;
+				props.style.height = props.size;
+			}
+		} else {
+			return null;
+		}
+
+		return React.createElement(component, props);
 	}
 }
 

--- a/src/registries/AppRegistry.tsx
+++ b/src/registries/AppRegistry.tsx
@@ -12,11 +12,9 @@ const defaultAppRoutePrefix = '/app';
  * @property {Map<string, App>} data  Map(immutablejs) of all apps
  */
 class AppRegistry extends MapRegistry<App> {
-	private BR: BlueRain;
 
-	constructor(ctx: BlueRain) {
+	constructor(private BR: BlueRain) {
 		super('AppRegistry');
-		this.BR = ctx;
 	}
 
 	/**

--- a/src/registries/DebuggerRegistry.ts
+++ b/src/registries/DebuggerRegistry.ts
@@ -9,12 +9,8 @@ import kebabCase from 'lodash.kebabcase';
  * @property {Map<string, Debugger>} data Storage Map of all debuggers
  */
 export default class DebuggerRegistry extends MapRegistry<Debugger> {
-	// data: Map<string, Debugger>;
-	BR: BlueRain;
-
-	constructor(ctx: BlueRain) {
+	constructor(private BR: BlueRain) {
 		super('DebuggerRegistry');
-		this.BR = ctx;
 	}
 
 	/**

--- a/src/registries/FilterRegistry.ts
+++ b/src/registries/FilterRegistry.ts
@@ -17,11 +17,8 @@ export type FilterRegistryItem = List<FilterRegistryListItem>;
  * filters and their respective functions
  */
 class FilterRegistry extends MapRegistry<FilterRegistryItem> {
-	BR: BlueRain;
-
-	constructor(ctx: BlueRain) {
+	constructor(private BR: BlueRain) {
 		super('FilterRegistry');
-		this.BR = ctx;
 	}
 
 	/**

--- a/src/registries/HooksRegistry.ts
+++ b/src/registries/HooksRegistry.ts
@@ -7,11 +7,7 @@ export type hookFn = (...args: any[]) => any;
  * All system hooks are stored in this registry
  */
 export default class HookRegistry {
-	BR: BlueRain;
-
-	constructor(ctx: BlueRain) {
-		this.BR = ctx;
-	}
+	constructor(private BR: BlueRain) {}
 
 	/**
 	 * Add a filter function to a hook. If the listener already exists, it will throw an Error.

--- a/src/registries/PluginRegistry.ts
+++ b/src/registries/PluginRegistry.ts
@@ -9,12 +9,8 @@ import kebabCase from 'lodash.kebabcase';
  * @property {Map<string, Plugin>} data Storage Map of all plugins
  */
 export default class PluginRegistry extends MapRegistry<Plugin> {
-	// data: Map<string, Plugin>;
-	BR: BlueRain;
-
-	constructor(ctx: BlueRain) {
+	constructor(private BR: BlueRain) {
 		super('PluginRegistry');
-		this.BR = ctx;
 	}
 
 	/**

--- a/test/apps/Alarm.ts
+++ b/test/apps/Alarm.ts
@@ -1,0 +1,12 @@
+import { App as BlueRainApp } from '../../src';
+import buildApp from './buildApp';
+
+export default buildApp({
+	appName: 'Alarm',
+	slug: 'alarm',
+	icon: {
+		type: 'image',
+		source:
+			'https://storage.googleapis.com/material-icons/external-assets/v4/icons/svg/ic_alarm_black_24px.svg'
+	}
+}) as BlueRainApp;

--- a/test/apps/Android.ts
+++ b/test/apps/Android.ts
@@ -1,0 +1,12 @@
+import { App as BlueRainApp } from '../../src';
+import CustomIcon from './CustomIcon';
+import buildApp from './buildApp';
+
+export default buildApp({
+	appName: 'Android',
+	slug: 'android',
+	icon: {
+		type: 'component',
+		component: CustomIcon
+	}
+}) as BlueRainApp;

--- a/test/apps/Apps.ts
+++ b/test/apps/Apps.ts
@@ -1,0 +1,9 @@
+import { App as BlueRainApp } from '../../src';
+import buildApp from './buildApp';
+
+export default buildApp({
+	appName: 'Apps',
+	slug: 'apps',
+	iconUrl:
+		'https://storage.googleapis.com/material-icons/external-assets/v4/icons/svg/ic_apps_black_24px.svg'
+}) as BlueRainApp;

--- a/test/apps/CustomIcon.tsx
+++ b/test/apps/CustomIcon.tsx
@@ -1,0 +1,14 @@
+import { BlueRain, BlueRainConsumer } from '../../src';
+import React from 'react';
+
+export default (props: any) => (
+	<BlueRainConsumer>
+		{(BR: BlueRain) => (
+			<BR.Components.Image
+				source="https://storage.googleapis.com/material-icons/external-assets/v4/icons/svg/ic_android_black_24px.svg"
+				style={{ ...props.style, width: props.size, height: props.size }}
+				{...props}
+			/>
+		)}
+	</BlueRainConsumer>
+);

--- a/test/apps/LightBulb.ts
+++ b/test/apps/LightBulb.ts
@@ -1,0 +1,10 @@
+import { App as BlueRainApp } from '../../src';
+import buildApp from './buildApp';
+
+export default buildApp({
+	appName: 'Light Bulb',
+	slug: 'lightBulb',
+	// tslint:disable-next-line:max-line-length
+	iconUrl:
+		'https://storage.googleapis.com/material-icons/external-assets/v4/icons/svg/ic_lightbulb_outline_black_24px.svg'
+}) as BlueRainApp;

--- a/test/apps/NoIcon.ts
+++ b/test/apps/NoIcon.ts
@@ -1,0 +1,7 @@
+import { App as BlueRainApp } from '../../src';
+import buildApp from './buildApp';
+
+export default buildApp({
+	appName: 'No Icon',
+	slug: 'no-icon'
+}) as BlueRainApp;

--- a/test/apps/Sites.ts
+++ b/test/apps/Sites.ts
@@ -1,0 +1,9 @@
+import { App as BlueRainApp } from '../../src';
+import buildApp from './buildApp';
+
+export default buildApp({
+	appName: 'Sites',
+	slug: 'sites',
+	iconUrl:
+		'https://storage.googleapis.com/material-icons/external-assets/v4/icons/svg/ic_account_balance_black_24px.svg'
+}) as BlueRainApp;

--- a/test/apps/buildApp.tsx
+++ b/test/apps/buildApp.tsx
@@ -1,0 +1,23 @@
+import { App as BlueRainApp, AppOptions, BlueRain, BlueRainConsumer, createApp } from '../../src';
+import React from 'react';
+
+export default (config: AppOptions) => {
+
+	const App = () => (
+		<BlueRainConsumer>
+			{(BR: BlueRain) => (
+				<BR.Components.Page>
+					<BR.Components.CenterLayout style={{ padding: 20 }}>
+						<BR.Components.ComponentState
+							title={config.appName}
+							description={`slug: ${config.slug}`}
+							imageSource={config.iconUrl}
+						/>
+					</BR.Components.CenterLayout>
+				</BR.Components.Page>
+			)}
+		</BlueRainConsumer>
+	);
+
+	return createApp(App, config) as BlueRainApp;
+};

--- a/test/stories/AppRegistry.stories.tsx
+++ b/test/stories/AppRegistry.stories.tsx
@@ -1,0 +1,17 @@
+import { BlueRain, BlueRainConsumer } from '../../src';
+import React from 'react';
+import storiesOf from '@blueeast/bluerain-storybook-addon';
+
+storiesOf('AppRegistry', module)
+
+	.add('getIconElement (image)', () => (
+		<BlueRainConsumer>
+			{(BR: BlueRain) => BR.Apps.getIconElement('alarm')}
+		</BlueRainConsumer>
+	))
+
+	.add('getIconElement (component)', () => (
+		<BlueRainConsumer>
+			{(BR: BlueRain) => BR.Apps.getIconElement('android', { size: 150 })}
+		</BlueRainConsumer>
+	));


### PR DESCRIPTION
## What I did
Implementation of app icons has been vague until this point. We wanted to have app icons to be any of the following:

- An image
- A react component
- A react component that is registered in the Component Registry
- An icon (BR.Components.Icon)

This PR fixes this issue by doing the following:

- Properly typing `icon` field in the App model
- Creates a utility method `BR.Apps.getIconElement(slug)` to manage rendering all these different types of icons.

## Usage
### Image Icons
```javascript
{
	appName: 'Alarm',
	slug: 'alarm',
	icon: {
		type: 'image',
		source: 'https://storage.googleapis.com/material-icons/external-assets/v4/icons/svg/ic_alarm_black_24px.svg'
	}
}
```

### Custom Component
```javascript
{
	appName: 'Android',
	slug: 'android',
	icon: {
		type: 'component',
		component: CustomIcon
	}
}
```

### Registered Component
Note that the `component` field is a string.

```javascript
{
	appName: 'Android',
	slug: 'android',
	icon: {
		type: 'component',
		component: 'RegisteredIcon'
	}
}
```

### BR.Components.Icon Component

```javascript
{
	appName: 'Rocket',
	slug: 'rocket',
	icon: {
		type: 'name',
		component: 'rocket'
	}
}
```
## How to test

### Is this testable with jest or storyshots?
Yes

### Are any of the existing tests are failing ?
No

### Does this need an update to the documentation?
Yes, but treat this PR as a doc before we build proper documentation

### Does it have breaking changes ?
No

If your answer is yes to any of these, please make sure to include it in your PR.


@bjavaid @amnajunaid please review the changes and merge them.
