### PR TITLE
Component Source

### DIFF
--- a/src/models/App.ts
+++ b/src/models/App.ts
@@ -37,6 +37,8 @@ export interface AppIconImage extends AppIconBase {
 	source: string;
 }
 
+export type AppIcon = AppIconComponent | AppIconImage | AppIconName;
+
 /** A BlueRain App options interface */
 export interface AppOptions {
 	/** Name of the app */
@@ -61,7 +63,7 @@ export interface AppOptions {
 	path?: string;
 
 	/** App's icon definition */
-	icon?: AppIconComponent | AppIconImage | AppIconName;
+	icon?: AppIcon | ((app: App, BR: BlueRain) => AppIcon);
 
 	/** If the app should be hidden in launcher listings */
 	hidden?: boolean;

--- a/src/registries/AppRegistry.tsx
+++ b/src/registries/AppRegistry.tsx
@@ -100,8 +100,6 @@ class AppRegistry extends MapRegistry<App> {
 						type: 'app',
 						slug: this.createSlug(app)
 					});
-
-					console.log(`${component} Component registered by `, this.BR.Components.getSource(component));
 				});
 			}
 

--- a/src/registries/AppRegistry.tsx
+++ b/src/registries/AppRegistry.tsx
@@ -164,7 +164,7 @@ class AppRegistry extends MapRegistry<App> {
 			throw new Error(`There's no app registered with "${name}" key in the registry.`);
 		}
 
-		const icon = app.icon;
+		const icon = (typeof app.icon === 'function') ? app.icon(app, this.BR) : app.icon;
 
 		if (!icon) {
 			return null;

--- a/src/registries/ComponentRegistry.ts
+++ b/src/registries/ComponentRegistry.ts
@@ -6,9 +6,15 @@ import isNil from 'lodash.isnil';
 
 export type ComponentRegistryHocItem = (...args: any[]) => React.ComponentType<any>;
 
+export interface ComponentSource {
+	type: 'plugin' | 'app' | 'custom';
+	slug: string;
+}
+
 export interface ComponentRegistryItem {
 	rawComponent: React.ComponentType;
 	hocs: ComponentRegistryHocItem[];
+	source?: ComponentSource;
 }
 
 /**
@@ -179,6 +185,30 @@ class ComponentRegistry extends MapRegistry<ComponentRegistryItem> {
 		}
 		const component: ComponentRegistryItem = super.get(name);
 		return component.rawComponent;
+	}
+
+	setSource(key: string, source: ComponentSource): void {
+		if (!this.has(key)) {
+			throw new Error(`No component registered with the key: "${key}"`);
+		}
+
+		if (!source || !source.type || !source.slug) {
+			throw new Error('Invalid source provided to setSource method of ComponentRegistry');
+		}
+
+		const componentItem: ComponentRegistryItem = this.data.get(key);
+		componentItem.source = source;
+
+		super.set(key, componentItem);
+	}
+
+	getSource(key: string): ComponentSource | undefined {
+		if (!this.has(key)) {
+			throw new Error(`No component registered with the key: "${key}"`);
+		}
+
+		const componentItem: ComponentRegistryItem = this.data.get(key);
+		return componentItem.source;
 	}
 }
 

--- a/src/registries/PluginRegistry.ts
+++ b/src/registries/PluginRegistry.ts
@@ -86,11 +86,6 @@ export default class PluginRegistry extends MapRegistry<Plugin> {
 						type: 'plugin',
 						slug: this.createSlug(plugin)
 					});
-
-					console.log(
-						`${component} Component registered by `,
-						this.BR.Components.getSource(component)
-					);
 				});
 			}
 

--- a/src/registries/PluginRegistry.ts
+++ b/src/registries/PluginRegistry.ts
@@ -20,7 +20,7 @@ export default class PluginRegistry extends MapRegistry<Plugin> {
 	add(key: string, plugin: MaybeEsModule<Plugin>): void;
 	add(plugin: MaybeEsModule<Plugin>): void;
 	add(key: string | MaybeEsModule<Plugin>, plugin?: MaybeEsModule<Plugin>) {
-		const { key: k, plugin: a } = getKeyAndItem(key, plugin);
+		const { key: k, plugin: a } = this.getKeyAndItem(key, plugin);
 		super.add(k, a);
 	}
 
@@ -33,7 +33,7 @@ export default class PluginRegistry extends MapRegistry<Plugin> {
 	set(key: string, plugin: MaybeEsModule<Plugin>): void;
 	set(plugin: MaybeEsModule<Plugin>): void;
 	set(key: string | MaybeEsModule<Plugin>, plugin?: MaybeEsModule<Plugin>) {
-		const { key: k, plugin: a } = getKeyAndItem(key, plugin);
+		const { key: k, plugin: a } = this.getKeyAndItem(key, plugin);
 		this.data = this.data.set(k, a);
 	}
 
@@ -82,6 +82,15 @@ export default class PluginRegistry extends MapRegistry<Plugin> {
 					}
 
 					this.BR.Components.set(component, plugin.components[component]);
+					this.BR.Components.setSource(component, {
+						type: 'plugin',
+						slug: this.createSlug(plugin)
+					});
+
+					console.log(
+						`${component} Component registered by `,
+						this.BR.Components.getSource(component)
+					);
 				});
 			}
 
@@ -93,40 +102,50 @@ export default class PluginRegistry extends MapRegistry<Plugin> {
 			}
 		});
 	}
+
+	/**
+	 * Returns a plugin slug, or generates one
+	 *
+	 * @param {Plugin} plugin
+	 * @returns {string}
+	 */
+	createSlug(plugin: Plugin): string {
+		return kebabCase(plugin.slug ? plugin.slug : plugin.pluginName);
+	}
+
+	/**
+	 * Takes an plugin, adds necessary fields and returns the processed plugin with a key
+	 * @param key
+	 * @param plugin
+	 */
+	private getKeyAndItem(
+		key: string | MaybeEsModule<Plugin>,
+		plugin?: MaybeEsModule<Plugin>
+	): { key: string; plugin: Plugin } {
+		if (typeof key !== 'string' && !isNil(key)) {
+			plugin = key as Plugin;
+			key = '';
+		}
+
+		if (!plugin) {
+			throw new Error('No plugin provided');
+		}
+
+		// ES modules
+		plugin = (plugin as EsModule<Plugin>).default ? (plugin as EsModule<Plugin>).default : plugin;
+
+		// Casting, to remove possiblity of undefined value is TS.
+		plugin = plugin as Plugin;
+
+		if (!plugin.pluginName) {
+			throw new Error('Plugin name not provided.');
+		}
+
+		const slug = this.createSlug(plugin);
+
+		plugin.slug = slug;
+
+		const strKey = key && typeof key === 'string' ? key : slug;
+		return { key: strKey, plugin };
+	}
 }
-
-/**
- * Takes an plugin, adds necessary fields and returns the processed plugin with a key
- * @param key
- * @param plugin
- */
-const getKeyAndItem = (
-	key: string | MaybeEsModule<Plugin>,
-	plugin?: MaybeEsModule<Plugin>
-): { key: string; plugin: Plugin } => {
-	if (typeof key !== 'string' && !isNil(key)) {
-		plugin = key as Plugin;
-		key = '';
-	}
-
-	if (!plugin) {
-		throw new Error('No plugin provided');
-	}
-
-	// ES modules
-	plugin = (plugin as EsModule<Plugin>).default ? (plugin as EsModule<Plugin>).default : plugin;
-
-	// Casting, to remove possiblity of undefined value is TS.
-	plugin = plugin as Plugin;
-
-	if (!plugin.pluginName) {
-		throw new Error('Plugin name not provided.');
-	}
-
-	const slug = kebabCase(plugin.slug ? plugin.slug : plugin.pluginName);
-
-	plugin.slug = slug;
-
-	const strKey = key && typeof key === 'string' ? key : slug;
-	return { key: strKey, plugin };
-};

--- a/test/apps/Apps.ts
+++ b/test/apps/Apps.ts
@@ -4,6 +4,9 @@ import buildApp from './buildApp';
 export default buildApp({
 	appName: 'Apps',
 	slug: 'apps',
-	iconUrl:
-		'https://storage.googleapis.com/material-icons/external-assets/v4/icons/svg/ic_apps_black_24px.svg'
+	icon: () => ({
+		type: 'image',
+		source:
+			'https://storage.googleapis.com/material-icons/external-assets/v4/icons/svg/ic_apps_black_24px.svg'
+	})
 }) as BlueRainApp;

--- a/test/stories/AppRegistry.stories.tsx
+++ b/test/stories/AppRegistry.stories.tsx
@@ -14,4 +14,10 @@ storiesOf('AppRegistry', module)
 		<BlueRainConsumer>
 			{(BR: BlueRain) => BR.Apps.getIconElement('android', { size: 150 })}
 		</BlueRainConsumer>
+	))
+
+	.add('getIconElement (thunk)', () => (
+		<BlueRainConsumer>
+			{(BR: BlueRain) => BR.Apps.getIconElement('apps', { size: 150 })}
+		</BlueRainConsumer>
 	));


### PR DESCRIPTION
## What I did
Sometimes we need to know where a certain component came from, i.e. which plugin/app registered it. This is helpful to know if we need to do some extra decision making in certain cases. For example if we are using a TextInput from Bootstrap or Material UI, either of these components may accomate extra props.

## API
Use the following getter and setter methods for source info:

```javascript
BR.Components.getSource(key);
BR.Components.setSource(key, source);
```

Source Interface

```typescript
interface ComponentSource {
	type: 'plugin' | 'app' | 'custom';
	slug: string;
}
```

## components property
Components registered through 'components' property of app or plugin get their source information saved automatically by BlueRain. 

## Example Usage

```javascript
const Icon = () => (
	<BlueRainConsumer>
		{(BR: BlueRain) => {

			let name;
			const source = BR.Components.getSource('Icon').slug;
			if (source === 'font-awesome') {
				name = 'rocket';
			} else if (source === 'material-ui') {
				name = 'airplane';
			}

			return <BR.Components.Icon name={name} />;
		}}
	</BlueRainConsumer>
)
```

## Other changes
One little feature that has been sneaked into this PR is that app.icon now accepts a thunks as well. 

## How to test

### Is this testable with jest or storyshots?
Yes

### Are any of the existing tests are failing ?
No

### Does this need an update to the documentation?
Yes

### Does it have breaking changes ?
No

If your answer is yes to any of these, please make sure to include it in your PR.


@bjavaid @amnajunaid please review the changes and merge them.
